### PR TITLE
Update handling of child IDs

### DIFF
--- a/lib/embedded_associations.rb
+++ b/lib/embedded_associations.rb
@@ -118,10 +118,13 @@ module EmbeddedAssociations
         if id = attrs['id']
           # can't use current_assoc.find(id), see http://stackoverflow.com/questions/11605120/autosave-ignored-on-has-many-relation-what-am-i-missing
           r = current_assoc.find{|r| r.id == id.to_i}
-          attrs = controller.send(:filter_attributes, r.class.name, attrs, :update)
-          handle_resource(child_definition, r, attrs) if child_definition
-          r.assign_attributes(attrs)
-          run_before_update_callbacks(r)
+
+          if r
+            attrs = controller.send(:filter_attributes, r.class.name, attrs, :update)
+            handle_resource(child_definition, r, attrs) if child_definition
+            r.assign_attributes(attrs)
+            run_before_update_callbacks(r)
+          end
         else
           inheritance_column = parent.class.reflect_on_association(name).klass.inheritance_column
           # need to pass in inheritance column in build to get correct class

--- a/spec/embedded_associations_spec.rb
+++ b/spec/embedded_associations_spec.rb
@@ -31,6 +31,7 @@ describe PostsController, type: :controller do
         hash[:tags] += [{},{}]
         json = post :update, :id => resource.id, post: hash
 
+        expect(json.response_code).to eq(200)
         expect(Post.count).to eq(1)
         expect(Tag.count).to eq(4)
 
@@ -41,6 +42,7 @@ describe PostsController, type: :controller do
         hash[:tags] = hash[:tags].take(1)
         json = post :update, :id => resource.id, post: hash
 
+        expect(json.response_code).to eq(200)
         expect(Post.count).to eq(1)
         expect(Tag.count).to eq(1)
 
@@ -51,6 +53,7 @@ describe PostsController, type: :controller do
         hash.delete(:tags)
         json = post :update, :id => resource.id, post: hash
 
+        expect(json.response_code).to eq(200)
         expect(Post.count).to eq(1)
         expect(Tag.count).to eq(2)
 
@@ -61,6 +64,7 @@ describe PostsController, type: :controller do
         hash[:tags].first[:name] = 'modified'
         json = post :update, :id => resource.id, post: hash
 
+        expect(json.response_code).to eq(200)
         expect(Post.count).to eq(1)
         expect(Tag.count).to eq(2)
 
@@ -79,6 +83,21 @@ describe PostsController, type: :controller do
         expect(Tag.count).to eq(2)
 
         expect(Tag.first.name).to eq("modified")
+      end
+
+      context "with a named tag and a uniqueness constraint" do
+        let(:tags) {[ Tag.create(name: "foo") ]}
+
+        it "should require an ID to supply existing records" do
+          json = post :update, id: resource.id, post: hash.merge(tags: [{ name: "foo" }])
+          expect(json.response_code).to eq(422)
+
+          json = post :update, id: resource.id, post: hash.merge(tags: [{ id: tags[0].id, name: "foo" }])
+          expect(json.response_code).to eq(200)
+          expect(Post.count).to eq(1)
+          expect(Tag.count).to eq(1)
+          expect(Tag.first.name).to eq("foo")
+        end
       end
     end
   end

--- a/spec/embedded_associations_spec.rb
+++ b/spec/embedded_associations_spec.rb
@@ -69,8 +69,18 @@ describe PostsController, type: :controller do
         Tag.all.each{ |t| expect(t.post).to_not be_nil }
       end
 
-    end
+      it "should ignore missing child records" do
+        hash[:tags].first[:name] = "modified"
+        hash[:tags] += [{ id: 0, name: "foo" }]
+        json = post :update, :id => resource.id, post: hash
 
+        expect(json.response_code).to eq(200)
+        expect(Post.count).to eq(1)
+        expect(Tag.count).to eq(2)
+
+        expect(Tag.first.name).to eq("modified")
+      end
+    end
   end
 
   describe "embedded belongs_to" do

--- a/spec/support/app/app/controllers/posts_controller.rb
+++ b/spec/support/app/app/controllers/posts_controller.rb
@@ -11,15 +11,21 @@ class PostsController < ApplicationController
   def create
     params = post_params
     handle_embedded_associations(resource, params)
-    resource.update_attributes(params)
-    render json: resource
+    if resource.update_attributes(params)
+      render json: resource
+    else
+      render json: {}, status: 422
+    end
   end
 
   def update
     params = post_params
     handle_embedded_associations(resource, params)
-    resource.update_attributes(params)
-    render json: resource
+    if resource.update_attributes(params)
+      render json: resource
+    else
+      render json: {}, status: 422
+    end
   end
 
   def destroy

--- a/spec/support/app/app/controllers/posts_controller.rb
+++ b/spec/support/app/app/controllers/posts_controller.rb
@@ -46,7 +46,7 @@ class PostsController < ApplicationController
       :title,
       comments: [:content, user: [:name, :email, account: [:note] ]],
       user: [:type, :name, :email, account: [:note] ],
-      tags: [:name],
+      tags: [:id, :name],
       category: [:name]
     )
   end

--- a/spec/support/app/app/models/tag.rb
+++ b/spec/support/app/app/models/tag.rb
@@ -1,3 +1,5 @@
 class Tag < ActiveRecord::Base
   belongs_to :post
+
+  validates :name, uniqueness: true, allow_blank: true
 end


### PR DESCRIPTION
[Starts #142734505](https://www.pivotaltracker.com/story/show/142734505)

Ignores embedded records that provide an "id" attribute but that cannot be found via that ID (presumably the record has since been destroyed).

Also adds a test to validate that duplicate values (attributes) must include their ID to reference an existing record ([related to #144628951](https://www.pivotaltracker.com/story/show/144628951)).